### PR TITLE
Bump jsonpickle

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests==2.20.0
-jsonpickle==0.7.1
+jsonpickle==1.2
 cachecontrol==0.11.7
 python-dateutil==2.5.3
 deprecation==2.0.6


### PR DESCRIPTION
Bump jsonpickle above the 1.x release to get rid of pip errors

```
ERROR: squareup 3.20191120.0 has requirement jsonpickle<1.0,>=0.7.1, but you'll have jsonpickle 1.1 which is incompatible.
```