### PR TITLE
Do not install the "tests" package via pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author='Square Developer Platform',
     author_email='developers@squareup.com',
     url='https://squareup.com/developers',
-    packages=find_packages(),
+    packages=find_packages(exclude=('tests',)),
     install_requires=[
         'requests>=2.9.1, <3.0',
         'jsonpickle>=0.7.1, <1.0',


### PR DESCRIPTION
Currently when installing via pip, two top-level packages are installed: `square` and `tests`. The tests package should not be installed via pip, as this causes conflicts with test collection tools (and this package should not be installing a module called "tests").