### PR TITLE
make setup.py consistent with requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'requests>=2.9.1, <3.0',
-        'jsonpickle>=0.7.1, <1.0',
+        'jsonpickle>=1.4.1, <2.0',
         'cachecontrol>=0.11.7, <1.0',
         'python-dateutil>=2.5.3, <3.0',
         'deprecation>=2.0.6'


### PR DESCRIPTION
https://github.com/square/square-python-sdk/blob/master/requirements.txt

Should resolve: #56 

It is a real blocker as people using `poetry` to manage dependencies will block on square because its `setup.py` pins an old jsonpickle that uses code no longer works in Python 3.10

![Screenshot 2021-09-16 at 18 35 12](https://user-images.githubusercontent.com/1122069/133650970-6af253d1-422a-4362-960e-79dc52385593.png)


Would be nice to see a release after this as well.