### PR TITLE
Remove unused dependency on dateutil

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "35.0.0.20240222"
 readme = "README.md"
 requires-python = ">=3.7"
 authors = [{name = "Square Developer Platform", email = "developers@squareup.com"}]
-dependencies = ["apimatic-core~=0.2.0", "apimatic-core-interfaces~=0.1.0", "apimatic-requests-client-adapter~=0.1.0", "python-dateutil~=2.8.1", "deprecation~=2.1"]
+dependencies = ["apimatic-core~=0.2.0", "apimatic-core-interfaces~=0.1.0", "apimatic-requests-client-adapter~=0.1.0", "deprecation~=2.1"]
 [project.optional-dependencies]
 testutils = ["pytest>=7.2.2"]
 [tool.setuptools.packages.find]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 apimatic-core~=0.2.0
 apimatic-core-interfaces~=0.1.0
 apimatic-requests-client-adapter~=0.1.0
-python-dateutil~=2.8.1
 deprecation~=2.1

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
         'apimatic-core~=0.1.0',
         'apimatic-core-interfaces~=0.1.0',
         'apimatic-requests-client-adapter~=0.1.0',
-        'python-dateutil~=2.8.1',
         'deprecation~=2.1'
     ],
     tests_require=[

--- a/tests/api/test_locations_api.py
+++ b/tests/api/test_locations_api.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import json
-import dateutil.parser
 
 from tests.api.api_test_base import ApiTestBase
 from apimatic_core.utilities.comparison_helper import ComparisonHelper


### PR DESCRIPTION
The dateutil dependency is only imported in tests, but not used. This PR removes the dependency.

Was initially going to open an issue to relax the version restriction of `~=2.8.1` since it conflicts with other packages, but then I noticed it isn't being used at all.