### PR TITLE
Release 41.0.0.20250319

### DIFF
--- a/doc/client.md
+++ b/doc/client.md
@@ -5,7 +5,7 @@ The following parameters are configurable for the API Client:
 
 | Parameter | Type | Description |
 |  --- | --- | --- |
-| `square_version` | `str` | Square Connect API versions<br>*Default*: `'2025-02-20'` |
+| `square_version` | `str` | Square Connect API versions<br>*Default*: `'2025-03-19'` |
 | `custom_url` | `str` | Sets the base URL requests are made to. Defaults to `https://connect.squareup.com`<br>*Default*: `'https://connect.squareup.com'` |
 | `environment` | `string` | The API environment. <br> **Default: `production`** |
 | `http_client_instance` | `HttpClient` | The Http Client passed from the sdk user for making requests |
@@ -24,7 +24,7 @@ The API client can be initialized as follows:
 
 ```python
 client = Client(
-    square_version='2025-02-20',
+    square_version='2025-03-19',
     bearer_auth_credentials=BearerAuthCredentials(
         access_token='AccessToken'
     ),
@@ -53,7 +53,7 @@ from square.http.auth.o_auth_2 import BearerAuthCredentials
 from square.client import Client
 
 client = Client(
-    square_version='2025-02-20',
+    square_version='2025-03-19',
     bearer_auth_credentials=BearerAuthCredentials(
         access_token='AccessToken'
     ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=61.0"]
 [project]
 name = "squareup"
 description = "Use Square APIs to manage and run business including payment, customer, product, inventory, and employee management."
-version = "40.1.0.220250220"
+version = "41.0.0.20250319"
 readme = "README.md"
 requires-python = ">=3.7"
 authors = [{name = "Square Developer Platform", email = "developers@squareup.com"}]

--- a/square/api/base_api.py
+++ b/square/api/base_api.py
@@ -22,7 +22,7 @@ class BaseApi(object):
 
     @staticmethod
     def user_agent():
-        return 'Square-Python-SDK/40.1.0.220250220 ({api-version}) {engine}/{engine-version} ({os-info}) {detail}'
+        return 'Square-Python-SDK/41.0.0.20250319 ({api-version}) {engine}/{engine-version} ({os-info}) {detail}'
 
     @staticmethod
     def user_agent_parameters():

--- a/square/client.py
+++ b/square/client.py
@@ -55,11 +55,11 @@ from square.api.webhook_subscriptions_api import WebhookSubscriptionsApi
 class Client(object):
     @staticmethod
     def sdk_version():
-        return '40.1.0.220250220'
+        return '41.0.0.20250319'
 
     @staticmethod
     def square_version():
-        return '2025-02-20'
+        return '2025-03-19'
 
     def user_agent_detail(self):
         return self.config.user_agent_detail
@@ -238,7 +238,7 @@ class Client(object):
                  retry_statuses=None, retry_methods=None,
                  environment='production',
                  custom_url='https://connect.squareup.com', access_token=None,
-                 bearer_auth_credentials=None, square_version='2025-02-20',
+                 bearer_auth_credentials=None, square_version='2025-03-19',
                  additional_headers={}, user_agent_detail='', config=None):
         self.config = config or Configuration(
             http_client_instance=http_client_instance,

--- a/square/configuration.py
+++ b/square/configuration.py
@@ -45,7 +45,7 @@ class Configuration(HttpClientConfiguration):
                  retry_statuses=None, retry_methods=None,
                  environment='production',
                  custom_url='https://connect.squareup.com', access_token=None,
-                 bearer_auth_credentials=None, square_version='2025-02-20',
+                 bearer_auth_credentials=None, square_version='2025-03-19',
                  additional_headers={}, user_agent_detail=''):
         if retry_methods is None:
             retry_methods = ['GET', 'PUT']


### PR DESCRIPTION
This prepares the `41.0.0.20250319` release. No significant changes are made in this release, but the versions are reflected to match the latest API.