### PR TITLE
Update workflows to use PYPI_API_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,6 @@ jobs:
       - name: Publish to pypi
         run: |
           poetry config repositories.remote https://upload.pypi.org/legacy/
-          poetry --no-interaction -v publish --build --repository remote --username "$PYPI_USERNAME" --password "$PYPI_PASSWORD"
+          poetry --no-interaction -v publish --build --repository remote -u __token__ -p "$PYPI_API_TOKEN"
         env:
-          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -50,7 +50,6 @@ jobs:
         working-directory: ./legacy
         run: |
           poetry config repositories.remote https://upload.pypi.org/legacy/
-          poetry --no-interaction -v publish --build --repository remote --username "$PYPI_USERNAME" --password "$PYPI_PASSWORD"
+          poetry --no-interaction -v publish --build --repository remote -u __token__ -p "$PYPI_API_TOKEN"
         env:
-          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This updates the GitHub publish workflow to use the `PYPI_API_TOKEN` directly rather than the separate `PYPI_USERNAME` and `PYPI_PASSWORD` secrets. This is functionally equivalent, but uses the more modern, simpler approach, as described in the [docs](https://pypi.org/help/).
