### PR TITLE
Visualization of the square-python-sdk

### DIFF
--- a/.codeboarding/API Service Modules.md
+++ b/.codeboarding/API Service Modules.md
@@ -1,0 +1,231 @@
+```mermaid
+graph LR
+    OAuth_Management["OAuth Management"]
+    Payments_Processing["Payments Processing"]
+    Bookings_Management["Bookings Management"]
+    Catalog_Management["Catalog Management"]
+    Customers_Management["Customers Management"]
+    Subscriptions_Management["Subscriptions Management"]
+    Locations_and_Transactions["Locations and Transactions"]
+    Terminal_Interactions["Terminal Interactions"]
+    Core_Utilities["Core Utilities"]
+    General_API_Clients["General API Clients"]
+    OAuth_Management -- "utilizes" --> Core_Utilities
+    Payments_Processing -- "utilizes" --> Core_Utilities
+    Bookings_Management -- "utilizes" --> Core_Utilities
+    Catalog_Management -- "utilizes" --> Core_Utilities
+    Customers_Management -- "utilizes" --> Core_Utilities
+    Subscriptions_Management -- "utilizes" --> Core_Utilities
+    Locations_and_Transactions -- "utilizes" --> Core_Utilities
+    Terminal_Interactions -- "utilizes" --> Core_Utilities
+    General_API_Clients -- "utilizes" --> Core_Utilities
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph provides an overview of the Square SDK's API service modules. These modules are organized into distinct components, each dedicated to a specific Square API category (e.g., Payments, Bookings, Customers). Each API-specific component encapsulates the business logic for interacting with its respective API endpoints. All these specialized API client components rely on a shared 'Core Utilities' component, which provides foundational functionalities such as HTTP response handling, API error processing, data serialization, and pagination.
+
+### OAuth Management
+This component provides functionalities for managing OAuth tokens, including obtaining, revoking, and retrieving token status, as well as authorizing applications. It includes both synchronous and asynchronous clients.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/o_auth/client.py#L17-L312" target="_blank" rel="noopener noreferrer">`square.o_auth.client.OAuthClient` (17:312)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/o_auth/raw_client.py#L20-L329" target="_blank" rel="noopener noreferrer">`square.o_auth.raw_client.RawOAuthClient` (20:329)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/o_auth/client.py#L315-L642" target="_blank" rel="noopener noreferrer">`square.o_auth.client.AsyncOAuthClient` (315:642)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/o_auth/raw_client.py#L332-L641" target="_blank" rel="noopener noreferrer">`square.o_auth.raw_client.AsyncRawOAuthClient` (332:641)</a>
+
+
+### Payments Processing
+This component handles all payment-related operations, such as creating, listing, updating, canceling, and completing payments. It also supports canceling payments by idempotency key. Both synchronous and asynchronous interfaces are available.
+
+
+**Related Classes/Methods**:
+
+- `square.payments.client.PaymentsClient` (full file reference)
+- `square.payments.raw_client.RawPaymentsClient` (full file reference)
+- `square.payments.client.AsyncPaymentsClient` (full file reference)
+- `square.payments.raw_client.AsyncRawPaymentsClient` (full file reference)
+
+
+### Bookings Management
+This component manages booking-related functionalities, including creating, listing, updating, and canceling bookings. It also provides interfaces for searching availability, retrieving business and location booking profiles, and managing custom attributes related to bookings.
+
+
+**Related Classes/Methods**:
+
+- `square.bookings.client.BookingsClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/raw_client.py#L30-L494" target="_blank" rel="noopener noreferrer">`square.bookings.raw_client.RawBookingsClient` (30:494)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/custom_attribute_definitions/client.py#L28-L335" target="_blank" rel="noopener noreferrer">`square.bookings.custom_attribute_definitions.client.CustomAttributeDefinitionsClient` (28:335)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/custom_attributes/client.py#L30-L403" target="_blank" rel="noopener noreferrer">`square.bookings.custom_attributes.client.CustomAttributesClient` (30:403)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/location_profiles/client.py#L18-L103" target="_blank" rel="noopener noreferrer">`square.bookings.location_profiles.client.LocationProfilesClient` (18:103)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/team_member_profiles/client.py#L19-L149" target="_blank" rel="noopener noreferrer">`square.bookings.team_member_profiles.client.TeamMemberProfilesClient` (19:149)</a>
+- `square.bookings.client.AsyncBookingsClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/raw_client.py#L497-L961" target="_blank" rel="noopener noreferrer">`square.bookings.raw_client.AsyncRawBookingsClient` (497:961)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/custom_attribute_definitions/client.py#L338-L685" target="_blank" rel="noopener noreferrer">`square.bookings.custom_attribute_definitions.client.AsyncCustomAttributeDefinitionsClient` (338:685)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/custom_attributes/client.py#L406-L827" target="_blank" rel="noopener noreferrer">`square.bookings.custom_attributes.client.AsyncCustomAttributesClient` (406:827)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/location_profiles/client.py#L106-L199" target="_blank" rel="noopener noreferrer">`square.bookings.location_profiles.client.AsyncLocationProfilesClient` (106:199)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/team_member_profiles/client.py#L152-L298" target="_blank" rel="noopener noreferrer">`square.bookings.team_member_profiles.client.AsyncTeamMemberProfilesClient` (152:298)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/custom_attribute_definitions/raw_client.py#L26-L280" target="_blank" rel="noopener noreferrer">`square.bookings.custom_attribute_definitions.raw_client.RawCustomAttributeDefinitionsClient` (26:280)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/custom_attribute_definitions/raw_client.py#L283-L537" target="_blank" rel="noopener noreferrer">`square.bookings.custom_attribute_definitions.raw_client.AsyncRawCustomAttributeDefinitionsClient` (283:537)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/location_profiles/raw_client.py#L7-L9" target="_blank" rel="noopener noreferrer">`square.bookings.location_profiles.raw_client.RawLocationProfilesClient` (7:9)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/location_profiles/raw_client.py#L12-L14" target="_blank" rel="noopener noreferrer">`square.bookings.location_profiles.raw_client.AsyncRawLocationProfilesClient` (12:14)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/team_member_profiles/raw_client.py#L16-L57" target="_blank" rel="noopener noreferrer">`square.bookings.team_member_profiles.raw_client.RawTeamMemberProfilesClient` (16:57)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/team_member_profiles/raw_client.py#L60-L101" target="_blank" rel="noopener noreferrer">`square.bookings.team_member_profiles.raw_client.AsyncRawTeamMemberProfilesClient` (60:101)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/custom_attributes/raw_client.py#L27-L349" target="_blank" rel="noopener noreferrer">`square.bookings.custom_attributes.raw_client.RawCustomAttributesClient` (27:349)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bookings/custom_attributes/raw_client.py#L352-L674" target="_blank" rel="noopener noreferrer">`square.bookings.custom_attributes.raw_client.AsyncRawCustomAttributesClient` (352:674)</a>
+
+
+### Catalog Management
+This component is responsible for managing a merchant's catalog, including batch operations for deleting, retrieving, and upserting catalog objects. It also provides functionalities for searching catalog items and updating item modifier lists and taxes.
+
+
+**Related Classes/Methods**:
+
+- `square.catalog.client.CatalogClient` (full file reference)
+- `square.catalog.raw_client.RawCatalogClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/catalog/images/client.py#L19-L122" target="_blank" rel="noopener noreferrer">`square.catalog.images.client.ImagesClient` (19:122)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/catalog/object/client.py#L18-L213" target="_blank" rel="noopener noreferrer">`square.catalog.object.client.ObjectClient` (18:213)</a>
+- `square.catalog.client.AsyncCatalogClient` (full file reference)
+- `square.catalog.raw_client.AsyncRawCatalogClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/catalog/images/client.py#L125-L246" target="_blank" rel="noopener noreferrer">`square.catalog.images.client.AsyncImagesClient` (125:246)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/catalog/object/client.py#L216-L435" target="_blank" rel="noopener noreferrer">`square.catalog.object.client.AsyncObjectClient` (216:435)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/catalog/images/raw_client.py#L24-L156" target="_blank" rel="noopener noreferrer">`square.catalog.images.raw_client.RawImagesClient` (24:156)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/catalog/images/raw_client.py#L159-L291" target="_blank" rel="noopener noreferrer">`square.catalog.images.raw_client.AsyncRawImagesClient` (159:291)</a>
+
+
+### Customers Management
+This component handles customer-related operations, such as creating, listing, updating, and deleting customer profiles. It also supports batch operations for customers, managing customer groups, segments, cards, and custom attributes.
+
+
+**Related Classes/Methods**:
+
+- `square.customers.client.CustomersClient` (full file reference)
+- `square.customers.raw_client.RawCustomersClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/customers/custom_attribute_definitions/client.py#L36-L432" target="_blank" rel="noopener noreferrer">`square.customers.custom_attribute_definitions.client.CustomAttributeDefinitionsClient` (36:432)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/customers/groups/client.py#L28-L346" target="_blank" rel="noopener noreferrer">`square.customers.groups.client.GroupsClient` (28:346)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/customers/segments/client.py#L19-L143" target="_blank" rel="noopener noreferrer">`square.customers.segments.client.SegmentsClient` (19:143)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/customers/cards/client.py#L17-L153" target="_blank" rel="noopener noreferrer">`square.customers.cards.client.CardsClient` (17:153)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/customers/custom_attributes/client.py#L26-L319" target="_blank" rel="noopener noreferrer">`square.customers.custom_attributes.client.CustomAttributesClient` (26:319)</a>
+- `square.customers.client.AsyncCustomersClient` (full file reference)
+- `square.customers.raw_client.AsyncRawCustomersClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/customers/custom_attribute_definitions/client.py#L435-L882" target="_blank" rel="noopener noreferrer">`square.customers.custom_attribute_definitions.client.AsyncCustomAttributeDefinitionsClient` (435:882)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/customers/groups/client.py#L349-L723" target="_blank" rel="noopener noreferrer">`square.customers.groups.client.AsyncGroupsClient` (349:723)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/customers/segments/client.py#L146-L286" target="_blank" rel="noopener noreferrer">`square.customers.segments.client.AsyncSegmentsClient` (146:286)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/customers/cards/client.py#L156-L308" target="_blank" rel="noopener noreferrer">`square.customers.cards.client.AsyncCardsClient` (156:308)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/customers/custom_attributes/client.py#L322-L647" target="_blank" rel="noopener noreferrer">`square.customers.custom_attributes.client.AsyncCustomAttributesClient` (322:647)</a>
+
+
+### Subscriptions Management
+This component manages customer subscriptions, including creating, updating, canceling, pausing, resuming, and swapping subscription plans. It also allows searching for subscriptions and listing subscription events.
+
+
+**Related Classes/Methods**:
+
+- `square.subscriptions.client.SubscriptionsClient` (full file reference)
+- `square.subscriptions.raw_client.RawSubscriptionsClient` (full file reference)
+- `square.subscriptions.client.AsyncSubscriptionsClient` (full file reference)
+- `square.subscriptions.raw_client.AsyncRawSubscriptionsClient` (full file reference)
+
+
+### Locations and Transactions
+This component handles operations related to business locations, including listing, creating, retrieving, and updating locations. It also provides functionalities for managing transactions and checkouts associated with locations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/locations/client.py#L29-L429" target="_blank" rel="noopener noreferrer">`square.locations.client.LocationsClient` (29:429)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/locations/raw_client.py#L28-L375" target="_blank" rel="noopener noreferrer">`square.locations.raw_client.RawLocationsClient` (28:375)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/locations/custom_attribute_definitions/client.py#L35-L344" target="_blank" rel="noopener noreferrer">`square.locations.custom_attribute_definitions.client.CustomAttributeDefinitionsClient` (35:344)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/locations/custom_attributes/client.py#L35-L431" target="_blank" rel="noopener noreferrer">`square.locations.custom_attributes.client.CustomAttributesClient` (35:431)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/locations/transactions/client.py#L16-L228" target="_blank" rel="noopener noreferrer">`square.locations.transactions.client.TransactionsClient` (16:228)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/locations/client.py#L432-L876" target="_blank" rel="noopener noreferrer">`square.locations.client.AsyncLocationsClient` (432:876)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/locations/raw_client.py#L378-L727" target="_blank" rel="noopener noreferrer">`square.locations.raw_client.AsyncRawLocationsClient` (378:727)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/locations/custom_attribute_definitions/client.py#L347-L696" target="_blank" rel="noopener noreferrer">`square.locations.custom_attribute_definitions.client.AsyncCustomAttributeDefinitionsClient` (347:696)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/locations/custom_attributes/client.py#L434-L878" target="_blank" rel="noopener noreferrer">`square.locations.custom_attributes.client.AsyncCustomAttributesClient` (434:878)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/locations/transactions/client.py#L231-L475" target="_blank" rel="noopener noreferrer">`square.locations.transactions.client.AsyncTransactionsClient` (231:475)</a>
+
+
+### Terminal Interactions
+This component facilitates interactions with Square Terminal devices, allowing for the dismissal of terminal actions, checkouts, and refunds. It provides interfaces for managing these terminal-specific operations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/terminal/client.py#L20-L139" target="_blank" rel="noopener noreferrer">`square.terminal.client.TerminalClient` (20:139)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/terminal/raw_client.py#L18-L139" target="_blank" rel="noopener noreferrer">`square.terminal.raw_client.RawTerminalClient` (18:139)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/terminal/actions/client.py#L20-L206" target="_blank" rel="noopener noreferrer">`square.terminal.actions.client.ActionsClient` (20:206)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/terminal/checkouts/client.py#L20-L199" target="_blank" rel="noopener noreferrer">`square.terminal.checkouts.client.CheckoutsClient` (20:199)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/terminal/refunds/client.py#L20-L198" target="_blank" rel="noopener noreferrer">`square.terminal.refunds.client.RefundsClient` (20:198)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/terminal/client.py#L142-L285" target="_blank" rel="noopener noreferrer">`square.terminal.client.AsyncTerminalClient` (142:285)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/terminal/raw_client.py#L142-L263" target="_blank" rel="noopener noreferrer">`square.terminal.raw_client.AsyncRawTerminalClient` (142:263)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/terminal/actions/client.py#L209-L429" target="_blank" rel="noopener noreferrer">`square.terminal.actions.client.AsyncActionsClient` (209:429)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/terminal/checkouts/client.py#L202-L417" target="_blank" rel="noopener noreferrer">`square.terminal.checkouts.client.AsyncCheckoutsClient` (202:417)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/terminal/refunds/client.py#L201-L413" target="_blank" rel="noopener noreferrer">`square.terminal.refunds.client.AsyncRefundsClient` (201:413)</a>
+
+
+### Core Utilities
+This foundational component provides essential utilities for the SDK, including handling unchecked base models, managing HTTP responses (both synchronous and asynchronous), processing API errors, performing serialization, encoding JSON, and facilitating pagination for list operations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/unchecked_base_model.py#L171-L269" target="_blank" rel="noopener noreferrer">`square.core.unchecked_base_model.construct_type` (171:269)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/http_response.py#L10-L27" target="_blank" rel="noopener noreferrer">`square.core.http_response.HttpResponse` (10:27)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/api_error.py#L14-L123" target="_blank" rel="noopener noreferrer">`square.core.api_error.ApiError` (14:123)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/http_response.py#L30-L47" target="_blank" rel="noopener noreferrer">`square.core.http_response.AsyncHttpResponse` (30:47)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/pagination.py#L37-L62" target="_blank" rel="noopener noreferrer">`square.core.pagination.SyncPager` (37:62)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/pagination.py#L65-L87" target="_blank" rel="noopener noreferrer">`square.core.pagination.AsyncPager` (65:87)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/serialization.py#L29-L154" target="_blank" rel="noopener noreferrer">`square.core.serialization.convert_and_respect_annotation_metadata` (29:154)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/jsonable_encoder.py#L31-L100" target="_blank" rel="noopener noreferrer">`square.core.jsonable_encoder.jsonable_encoder` (31:100)</a>
+
+
+### General API Clients
+This component groups various other top-level API clients that interact with different Square API domains, such as Webhooks, Inventory, Team Members, Orders, Cards, and Checkout. These clients provide a wide range of functionalities specific to their respective domains.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/webhooks/client.py#L13-L29" target="_blank" rel="noopener noreferrer">`square.webhooks.client.WebhooksClient` (13:29)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/webhooks/raw_client.py#L7-L9" target="_blank" rel="noopener noreferrer">`square.webhooks.raw_client.RawWebhooksClient` (7:9)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/webhooks/event_types/client.py#L12-L56" target="_blank" rel="noopener noreferrer">`square.webhooks.event_types.client.EventTypesClient` (12:56)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/webhooks/subscriptions/client.py#L29-L378" target="_blank" rel="noopener noreferrer">`square.webhooks.subscriptions.client.SubscriptionsClient` (29:378)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/webhooks/client.py#L32-L48" target="_blank" rel="noopener noreferrer">`square.webhooks.client.AsyncWebhooksClient` (32:48)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/webhooks/raw_client.py#L12-L14" target="_blank" rel="noopener noreferrer">`square.webhooks.raw_client.AsyncRawWebhooksClient` (12:14)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/webhooks/event_types/client.py#L59-L111" target="_blank" rel="noopener noreferrer">`square.webhooks.event_types.client.AsyncEventTypesClient` (59:111)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/webhooks/subscriptions/client.py#L381-L788" target="_blank" rel="noopener noreferrer">`square.webhooks.subscriptions.client.AsyncSubscriptionsClient` (381:788)</a>
+- `square.inventory.client.InventoryClient` (full file reference)
+- `square.inventory.raw_client.RawInventoryClient` (full file reference)
+- `square.inventory.client.AsyncInventoryClient` (full file reference)
+- `square.inventory.raw_client.AsyncRawInventoryClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/team_members/client.py#L26-L419" target="_blank" rel="noopener noreferrer">`square.team_members.client.TeamMembersClient` (26:419)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/team_members/raw_client.py#L29-L373" target="_blank" rel="noopener noreferrer">`square.team_members.raw_client.RawTeamMembersClient` (29:373)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/team_members/wage_setting/client.py#L17-L135" target="_blank" rel="noopener noreferrer">`square.team_members.wage_setting.client.WageSettingClient` (17:135)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/team_members/client.py#L422-L869" target="_blank" rel="noopener noreferrer">`square.team_members.client.AsyncTeamMembersClient` (422:869)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/team_members/raw_client.py#L376-L720" target="_blank" rel="noopener noreferrer">`square.team_members.raw_client.AsyncRawTeamMembersClient` (376:720)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/team_members/wage_setting/client.py#L138-L274" target="_blank" rel="noopener noreferrer">`square.team_members.wage_setting.client.AsyncWageSettingClient` (138:274)</a>
+- `square.orders.client.OrdersClient` (full file reference)
+- `square.orders.raw_client.RawOrdersClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/orders/custom_attribute_definitions/client.py#L27-L329" target="_blank" rel="noopener noreferrer">`square.orders.custom_attribute_definitions.client.CustomAttributeDefinitionsClient` (27:329)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/orders/custom_attributes/client.py#L35-L457" target="_blank" rel="noopener noreferrer">`square.orders.custom_attributes.client.CustomAttributesClient` (35:457)</a>
+- `square.orders.client.AsyncOrdersClient` (full file reference)
+- `square.orders.raw_client.AsyncRawOrdersClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/orders/custom_attribute_definitions/client.py#L332-L674" target="_blank" rel="noopener noreferrer">`square.orders.custom_attribute_definitions.client.AsyncCustomAttributeDefinitionsClient` (332:674)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/orders/custom_attributes/client.py#L460-L930" target="_blank" rel="noopener noreferrer">`square.orders.custom_attributes.client.AsyncCustomAttributesClient` (460:930)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/cards/client.py#L26-L276" target="_blank" rel="noopener noreferrer">`square.cards.client.CardsClient` (26:276)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/cards/raw_client.py#L23-L177" target="_blank" rel="noopener noreferrer">`square.cards.raw_client.RawCardsClient` (23:177)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/cards/client.py#L279-L563" target="_blank" rel="noopener noreferrer">`square.cards.client.AsyncCardsClient` (279:563)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/cards/raw_client.py#L180-L334" target="_blank" rel="noopener noreferrer">`square.cards.raw_client.AsyncRawCardsClient` (180:334)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/checkout/client.py#L22-L178" target="_blank" rel="noopener noreferrer">`square.checkout.client.CheckoutClient` (22:178)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/checkout/raw_client.py#L25-L208" target="_blank" rel="noopener noreferrer">`square.checkout.raw_client.RawCheckoutClient` (25:208)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/checkout/payment_links/client.py#L30-L313" target="_blank" rel="noopener noreferrer">`square.checkout.payment_links.client.PaymentLinksClient` (30:313)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/checkout/client.py#L181-L369" target="_blank" rel="noopener noreferrer">`square.checkout.client.AsyncCheckoutClient` (181:369)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/checkout/raw_client.py#L211-L394" target="_blank" rel="noopener noreferrer">`square.checkout.raw_client.AsyncRawCheckoutClient` (211:394)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/checkout/payment_links/client.py#L316-L641" target="_blank" rel="noopener noreferrer">`square.checkout.payment_links.client.AsyncPaymentLinksClient` (316:641)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Core Communication & Utilities.md
+++ b/.codeboarding/Core Communication & Utilities.md
@@ -1,0 +1,88 @@
+```mermaid
+graph LR
+    HTTP_Client_Core["HTTP Client Core"]
+    Client_Wrapper_Base["Client Wrapper Base"]
+    Data_Encoding_Utilities["Data Encoding & Utilities"]
+    Data_Serialization_Models["Data Serialization & Models"]
+    API_Error_Handling["API Error Handling"]
+    API_Pagination["API Pagination"]
+    Client_Wrapper_Base -- "uses" --> HTTP_Client_Core
+    Client_Wrapper_Base -- "processes data with" --> Data_Encoding_Utilities
+    Client_Wrapper_Base -- "handles data models via" --> Data_Serialization_Models
+    Client_Wrapper_Base -- "raises" --> API_Error_Handling
+    Client_Wrapper_Base -- "integrates" --> API_Pagination
+    Data_Serialization_Models -- "depends on" --> Data_Encoding_Utilities
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The 'Core Communication & Utilities' component serves as the foundational layer for the entire SDK, providing essential services for interacting with the Square API. Its primary purpose is to abstract the complexities of HTTP communication, data handling, error management, and pagination, allowing higher-level API-specific components to focus on business logic. This component ensures reliable and efficient data exchange, proper serialization and deserialization of various data types, and a consistent approach to error reporting and paginated results across the SDK.
+
+### HTTP Client Core
+Manages the execution of synchronous and asynchronous HTTP requests and responses, forming the lowest level of network communication within the SDK.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/http_client.py#L148-L321" target="_blank" rel="noopener noreferrer">`square.core.http_client.HttpClient` (148:321)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/http_client.py#L324-L497" target="_blank" rel="noopener noreferrer">`square.core.http_client.AsyncHttpClient` (324:497)</a>
+
+
+### Client Wrapper Base
+Provides a foundational layer for all API clients, abstracting the underlying HTTP communication and integrating core utilities for request and response handling.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/client_wrapper.py#L9-L46" target="_blank" rel="noopener noreferrer">`square.core.client_wrapper.BaseClientWrapper` (9:46)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/client_wrapper.py#L49-L65" target="_blank" rel="noopener noreferrer">`square.core.client_wrapper.SyncClientWrapper` (49:65)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/client_wrapper.py#L68-L84" target="_blank" rel="noopener noreferrer">`square.core.client_wrapper.AsyncClientWrapper` (68:84)</a>
+
+
+### Data Encoding & Utilities
+Responsible for encoding various data types, such as query parameters and file uploads, into formats suitable for HTTP requests, and provides general utility functions for data manipulation like removing None values.
+
+
+**Related Classes/Methods**:
+
+- `square.core.query_encoder` (full file reference)
+- `square.core.file` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/remove_none_from_dict.py#L6-L11" target="_blank" rel="noopener noreferrer">`square.core.remove_none_from_dict` (6:11)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/jsonable_encoder.py#L31-L100" target="_blank" rel="noopener noreferrer">`square.core.jsonable_encoder` (31:100)</a>
+
+
+### Data Serialization & Models
+Handles the complex serialization and deserialization of data, particularly for Pydantic models, and provides utilities for working with these models and datetime objects, ensuring data integrity and proper formatting.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/unchecked_base_model.py#L36-L124" target="_blank" rel="noopener noreferrer">`square.core.unchecked_base_model.UncheckedBaseModel` (36:124)</a>
+- `square.core.serialization` (full file reference)
+- `square.core.pydantic_utilities` (full file reference)
+- `square.core.datetime_utils` (full file reference)
+
+
+### API Error Handling
+Defines the structure for API-specific errors and provides mechanisms for their handling, allowing the SDK to gracefully manage and report issues encountered during API interactions.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/api_error.py#L14-L123" target="_blank" rel="noopener noreferrer">`square.core.api_error.ApiError` (14:123)</a>
+
+
+### API Pagination
+Provides helper classes for iterating over paginated API responses, simplifying the process of retrieving large datasets from the Square API in both synchronous and asynchronous contexts.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/pagination.py#L37-L62" target="_blank" rel="noopener noreferrer">`square.core.pagination.SyncPager` (37:62)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/pagination.py#L65-L87" target="_blank" rel="noopener noreferrer">`square.core.pagination.AsyncPager` (65:87)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/SDK Clients.md
+++ b/.codeboarding/SDK Clients.md
@@ -1,0 +1,258 @@
+```mermaid
+graph LR
+    Legacy_SDK_Client["Legacy SDK Client"]
+    New_SDK_Synchronous_Client["New SDK Synchronous Client"]
+    New_SDK_Asynchronous_Client["New SDK Asynchronous Client"]
+    Legacy_API_Category_Modules["Legacy API Category Modules"]
+    New_SDK_Synchronous_API_Category_Clients["New SDK Synchronous API Category Clients"]
+    New_SDK_Asynchronous_API_Category_Clients["New SDK Asynchronous API Category Clients"]
+    Legacy_SDK_Core["Legacy SDK Core"]
+    New_SDK_Core["New SDK Core"]
+    Legacy_SDK_Client -- "initializes and uses" --> Legacy_API_Category_Modules
+    Legacy_SDK_Client -- "configures and authenticates with" --> Legacy_SDK_Core
+    New_SDK_Synchronous_Client -- "initializes and uses" --> New_SDK_Synchronous_API_Category_Clients
+    New_SDK_Synchronous_Client -- "uses" --> New_SDK_Core
+    New_SDK_Asynchronous_Client -- "initializes and uses" --> New_SDK_Asynchronous_API_Category_Clients
+    New_SDK_Asynchronous_Client -- "uses" --> New_SDK_Core
+    Legacy_API_Category_Modules -- "inherits from" --> Legacy_SDK_Core
+    New_SDK_Synchronous_API_Category_Clients -- "uses" --> New_SDK_Core
+    New_SDK_Asynchronous_API_Category_Clients -- "uses" --> New_SDK_Core
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph illustrates the structure and interactions within the SDK Clients subsystem, which provides the primary interfaces for interacting with the Square API. It distinguishes between legacy and modern SDK approaches, offering both synchronous and asynchronous clients for the latter. The core purpose is to aggregate various API-specific modules and manage underlying HTTP communication and authentication, enabling developers to access Square's services programmatically.
+
+### Legacy SDK Client
+This component serves as the main entry point for interacting with the Square API using the legacy SDK. It initializes and provides access to various API categories (e.g., Mobile Authorization, OAuth, V1 Transactions, etc.) as lazy-loaded properties. It also handles global configuration and OAuth2 authentication.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L55-L269" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client` (55:269)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L235-L269" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:__init__` (235:269)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L68-L69" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:mobile_authorization` (68:69)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L72-L73" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:o_auth` (72:73)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L76-L77" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:v1_transactions` (76:77)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L80-L81" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:apple_pay` (80:81)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L84-L85" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:bank_accounts` (84:85)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L88-L89" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:bookings` (88:89)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L92-L93" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:booking_custom_attributes` (92:93)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L96-L97" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:cards` (96:97)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L100-L101" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:cash_drawers` (100:101)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L104-L105" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:catalog` (104:105)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L108-L109" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:customers` (108:109)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L112-L113" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:customer_custom_attributes` (112:113)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L116-L117" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:customer_groups` (116:117)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L120-L121" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:customer_segments` (120:121)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L124-L125" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:devices` (124:125)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L128-L129" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:disputes` (128:129)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L132-L133" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:employees` (132:133)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L136-L137" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:events` (136:137)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L140-L141" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:gift_cards` (140:141)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L144-L145" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:gift_card_activities` (144:145)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L148-L149" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:inventory` (148:149)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L152-L153" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:invoices` (152:153)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L156-L157" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:labor` (156:157)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L160-L161" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:locations` (160:161)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L164-L165" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:location_custom_attributes` (164:165)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L168-L169" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:checkout` (168:169)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L172-L173" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:transactions` (172:173)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L176-L177" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:loyalty` (176:177)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L180-L181" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:merchants` (180:181)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L184-L185" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:merchant_custom_attributes` (184:185)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L188-L189" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:orders` (188:189)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L192-L193" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:order_custom_attributes` (192:193)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L196-L197" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:payments` (196:197)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L200-L201" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:payouts` (200:201)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L204-L205" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:refunds` (204:205)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L208-L209" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:sites` (208:209)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L212-L213" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:snippets` (212:213)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L216-L217" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:subscriptions` (216:217)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L220-L221" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:team` (220:221)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L224-L225" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:terminal` (224:225)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L228-L229" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:vendors` (228:229)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L232-L233" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:webhook_subscriptions` (232:233)</a>
+
+
+### New SDK Synchronous Client
+This component is the primary synchronous client for the new Square Python SDK. It provides organized access to different Square API domains (e.g., Mobile, OAuth, V1 Transactions) through dedicated client objects, leveraging a synchronous client wrapper for underlying HTTP operations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/client.py#L79-L175" target="_blank" rel="noopener noreferrer">`square.client.Square` (79:175)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/client.py#L117-L175" target="_blank" rel="noopener noreferrer">`square.client.Square:__init__` (117:175)</a>
+
+
+### New SDK Asynchronous Client
+This component is the primary asynchronous client for the new Square Python SDK. Similar to its synchronous counterpart, it offers structured access to various Square API domains, but it utilizes an asynchronous client wrapper for non-blocking HTTP requests.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/client.py#L178-L274" target="_blank" rel="noopener noreferrer">`square.client.AsyncSquare` (178:274)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/client.py#L216-L274" target="_blank" rel="noopener noreferrer">`square.client.AsyncSquare:__init__` (216:274)</a>
+
+
+### Legacy API Category Modules
+These modules encapsulate the specific API endpoints and operations for different Square API categories within the legacy SDK. Each module corresponds to a distinct domain of Square's services, such as payments, customers, or catalog management.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/mobile_authorization_api.py#L13-L73" target="_blank" rel="noopener noreferrer">`square_legacy.api.mobile_authorization_api.MobileAuthorizationApi` (13:73)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/o_auth_api.py#L13-L188" target="_blank" rel="noopener noreferrer">`square_legacy.api.o_auth_api.OAuthApi` (13:188)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/v1_transactions_api.py#L14-L186" target="_blank" rel="noopener noreferrer">`square_legacy.api.v1_transactions_api.V1TransactionsApi` (14:186)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/apple_pay_api.py#L13-L82" target="_blank" rel="noopener noreferrer">`square_legacy.api.apple_pay_api.ApplePayApi` (13:82)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/bank_accounts_api.py#L13-L165" target="_blank" rel="noopener noreferrer">`square_legacy.api.bank_accounts_api.BankAccountsApi` (13:165)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/bookings_api.py#L13-L682" target="_blank" rel="noopener noreferrer">`square_legacy.api.bookings_api.BookingsApi` (13:682)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/booking_custom_attributes_api.py#L13-L663" target="_blank" rel="noopener noreferrer">`square_legacy.api.booking_custom_attributes_api.BookingCustomAttributesApi` (13:663)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/cards_api.py#L13-L212" target="_blank" rel="noopener noreferrer">`square_legacy.api.cards_api.CardsApi` (13:212)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/cash_drawers_api.py#L13-L195" target="_blank" rel="noopener noreferrer">`square_legacy.api.cash_drawers_api.CashDrawersApi` (13:195)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/catalog_api.py#L14-L833" target="_blank" rel="noopener noreferrer">`square_legacy.api.catalog_api.CatalogApi` (14:833)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/customers_api.py#L14-L753" target="_blank" rel="noopener noreferrer">`square_legacy.api.customers_api.CustomersApi` (14:753)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/customer_custom_attributes_api.py#L13-L665" target="_blank" rel="noopener noreferrer">`square_legacy.api.customer_custom_attributes_api.CustomerCustomAttributesApi` (13:665)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/customer_groups_api.py#L13-L249" target="_blank" rel="noopener noreferrer">`square_legacy.api.customer_groups_api.CustomerGroupsApi` (13:249)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/customer_segments_api.py#L13-L114" target="_blank" rel="noopener noreferrer">`square_legacy.api.customer_segments_api.CustomerSegmentsApi` (13:114)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/devices_api.py#L13-L270" target="_blank" rel="noopener noreferrer">`square_legacy.api.devices_api.DevicesApi` (13:270)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/disputes_api.py#L14-L469" target="_blank" rel="noopener noreferrer">`square_legacy.api.disputes_api.DisputesApi` (14:469)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/employees_api.py#L14-L117" target="_blank" rel="noopener noreferrer">`square_legacy.api.employees_api.EmployeesApi` (14:117)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/events_api.py#L13-L172" target="_blank" rel="noopener noreferrer">`square_legacy.api.events_api.EventsApi` (13:172)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/gift_cards_api.py#L13-L379" target="_blank" rel="noopener noreferrer">`square_legacy.api.gift_cards_api.GiftCardsApi` (13:379)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/gift_card_activities_api.py#L13-L172" target="_blank" rel="noopener noreferrer">`square_legacy.api.gift_card_activities_api.GiftCardActivitiesApi` (13:172)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/inventory_api.py#L14-L661" target="_blank" rel="noopener noreferrer">`square_legacy.api.inventory_api.InventoryApi` (14:661)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/invoices_api.py#L14-L561" target="_blank" rel="noopener noreferrer">`square_legacy.api.invoices_api.InvoicesApi` (14:561)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/labor_api.py#L14-L796" target="_blank" rel="noopener noreferrer">`square_legacy.api.labor_api.LaborApi` (14:796)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/locations_api.py#L13-L203" target="_blank" rel="noopener noreferrer">`square_legacy.api.locations_api.LocationsApi` (13:203)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/location_custom_attributes_api.py#L13-L703" target="_blank" rel="noopener noreferrer">`square_legacy.api.location_custom_attributes_api.LocationCustomAttributesApi` (13:703)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/checkout_api.py#L14-L479" target="_blank" rel="noopener noreferrer">`square_legacy.api.checkout_api.CheckoutApi` (14:479)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/transactions_api.py#L14-L252" target="_blank" rel="noopener noreferrer">`square_legacy.api.transactions_api.TransactionsApi` (14:252)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/loyalty_api.py#L14-L989" target="_blank" rel="noopener noreferrer">`square_legacy.api.loyalty_api.LoyaltyApi` (14:989)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/merchants_api.py#L13-L111" target="_blank" rel="noopener noreferrer">`square_legacy.api.merchants_api.MerchantsApi` (13:111)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/merchant_custom_attributes_api.py#L13-L703" target="_blank" rel="noopener noreferrer">`square_legacy.api.merchant_custom_attributes_api.MerchantCustomAttributesApi` (13:703)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/orders_api.py#L13-L444" target="_blank" rel="noopener noreferrer">`square_legacy.api.orders_api.OrdersApi` (13:444)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/order_custom_attributes_api.py#L13-L714" target="_blank" rel="noopener noreferrer">`square_legacy.api.order_custom_attributes_api.OrderCustomAttributesApi` (13:714)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/payments_api.py#L13-L469" target="_blank" rel="noopener noreferrer">`square_legacy.api.payments_api.PaymentsApi` (13:469)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/payouts_api.py#L13-L220" target="_blank" rel="noopener noreferrer">`square_legacy.api.payouts_api.PayoutsApi` (13:220)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/refunds_api.py#L14-L239" target="_blank" rel="noopener noreferrer">`square_legacy.api.refunds_api.RefundsApi` (14:239)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/sites_api.py#L13-L55" target="_blank" rel="noopener noreferrer">`square_legacy.api.sites_api.SitesApi` (13:55)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/snippets_api.py#L13-L175" target="_blank" rel="noopener noreferrer">`square_legacy.api.snippets_api.SnippetsApi` (13:175)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/subscriptions_api.py#L13-L637" target="_blank" rel="noopener noreferrer">`square_legacy.api.subscriptions_api.SubscriptionsApi` (13:637)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/team_api.py#L13-L617" target="_blank" rel="noopener noreferrer">`square_legacy.api.team_api.TeamApi` (13:617)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/terminal_api.py#L13-L673" target="_blank" rel="noopener noreferrer">`square_legacy.api.terminal_api.TerminalApi` (13:673)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/vendors_api.py#L13-L332" target="_blank" rel="noopener noreferrer">`square_legacy.api.vendors_api.VendorsApi` (13:332)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/webhook_subscriptions_api.py#L13-L405" target="_blank" rel="noopener noreferrer">`square_legacy.api.webhook_subscriptions_api.WebhookSubscriptionsApi` (13:405)</a>
+
+
+### New SDK Synchronous API Category Clients
+These modules represent the synchronous client interfaces for specific API categories in the new SDK. They provide methods to interact with various Square API functionalities in a blocking manner.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/mobile/client.py#L15-L75" target="_blank" rel="noopener noreferrer">`square.mobile.client.MobileClient` (15:75)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/o_auth/client.py#L17-L312" target="_blank" rel="noopener noreferrer">`square.o_auth.client.OAuthClient` (17:312)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/v1transactions/client.py#L17-L190" target="_blank" rel="noopener noreferrer">`square.v1transactions.client.V1TransactionsClient` (17:190)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/apple_pay/client.py#L15-L74" target="_blank" rel="noopener noreferrer">`square.apple_pay.client.ApplePayClient` (15:74)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bank_accounts/client.py#L20-L186" target="_blank" rel="noopener noreferrer">`square.bank_accounts.client.BankAccountsClient` (20:186)</a>
+- `square.bookings.client.BookingsClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/cards/client.py#L26-L276" target="_blank" rel="noopener noreferrer">`square.cards.client.CardsClient` (26:276)</a>
+- `square.catalog.client.CatalogClient` (full file reference)
+- `square.customers.client.CustomersClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/devices/client.py#L22-L156" target="_blank" rel="noopener noreferrer">`square.devices.client.DevicesClient` (22:156)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/disputes/client.py#L32-L338" target="_blank" rel="noopener noreferrer">`square.disputes.client.DisputesClient` (32:338)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/employees/client.py#L20-L148" target="_blank" rel="noopener noreferrer">`square.employees.client.EmployeesClient` (20:148)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/events/client.py#L19-L167" target="_blank" rel="noopener noreferrer">`square.events.client.EventsClient` (19:167)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/gift_cards/client.py#L30-L392" target="_blank" rel="noopener noreferrer">`square.gift_cards.client.GiftCardsClient` (30:392)</a>
+- `square.inventory.client.InventoryClient` (full file reference)
+- `square.invoices.client.InvoicesClient` (full file reference)
+- `square.labor.client.LaborClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/locations/client.py#L29-L429" target="_blank" rel="noopener noreferrer">`square.locations.client.LocationsClient` (29:429)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/loyalty/client.py#L22-L105" target="_blank" rel="noopener noreferrer">`square.loyalty.client.LoyaltyClient` (22:105)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/merchants/client.py#L23-L143" target="_blank" rel="noopener noreferrer">`square.merchants.client.MerchantsClient` (23:143)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/checkout/client.py#L22-L178" target="_blank" rel="noopener noreferrer">`square.checkout.client.CheckoutClient` (22:178)</a>
+- `square.orders.client.OrdersClient` (full file reference)
+- `square.payments.client.PaymentsClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/payouts/client.py#L24-L276" target="_blank" rel="noopener noreferrer">`square.payouts.client.PayoutsClient` (24:276)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/refunds/client.py#L27-L386" target="_blank" rel="noopener noreferrer">`square.refunds.client.RefundsClient` (27:386)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/sites/client.py#L12-L54" target="_blank" rel="noopener noreferrer">`square.sites.client.SitesClient` (12:54)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/snippets/client.py#L18-L146" target="_blank" rel="noopener noreferrer">`square.snippets.client.SnippetsClient` (18:146)</a>
+- `square.subscriptions.client.SubscriptionsClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/team_members/client.py#L26-L419" target="_blank" rel="noopener noreferrer">`square.team_members.client.TeamMembersClient` (26:419)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/team/client.py#L19-L180" target="_blank" rel="noopener noreferrer">`square.team.client.TeamClient` (19:180)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/terminal/client.py#L20-L139" target="_blank" rel="noopener noreferrer">`square.terminal.client.TerminalClient` (20:139)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/vendors/client.py#L25-L370" target="_blank" rel="noopener noreferrer">`square.vendors.client.VendorsClient` (25:370)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/cash_drawers/client.py#L11-L25" target="_blank" rel="noopener noreferrer">`square.cash_drawers.client.CashDrawersClient` (11:25)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/webhooks/client.py#L13-L29" target="_blank" rel="noopener noreferrer">`square.webhooks.client.WebhooksClient` (13:29)</a>
+
+
+### New SDK Asynchronous API Category Clients
+These modules represent the asynchronous client interfaces for specific API categories in the new SDK. They provide methods to interact with various Square API functionalities using non-blocking operations, suitable for concurrent programming.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/mobile/client.py#L78-L146" target="_blank" rel="noopener noreferrer">`square.mobile.client.AsyncMobileClient` (78:146)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/o_auth/client.py#L315-L642" target="_blank" rel="noopener noreferrer">`square.o_auth.client.AsyncOAuthClient` (315:642)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/v1transactions/client.py#L193-L390" target="_blank" rel="noopener noreferrer">`square.v1transactions.client.AsyncV1TransactionsClient` (193:390)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/apple_pay/client.py#L77-L144" target="_blank" rel="noopener noreferrer">`square.apple_pay.client.AsyncApplePayClient` (77:144)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/bank_accounts/client.py#L189-L379" target="_blank" rel="noopener noreferrer">`square.bank_accounts.client.AsyncBankAccountsClient` (189:379)</a>
+- `square.bookings.client.AsyncBookingsClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/cards/client.py#L279-L563" target="_blank" rel="noopener noreferrer">`square.cards.client.AsyncCardsClient` (279:563)</a>
+- `square.catalog.client.AsyncCatalogClient` (full file reference)
+- `square.customers.client.AsyncCustomersClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/devices/client.py#L159-L311" target="_blank" rel="noopener noreferrer">`square.devices.client.AsyncDevicesClient` (159:311)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/disputes/client.py#L341-L697" target="_blank" rel="noopener noreferrer">`square.disputes.client.AsyncDisputesClient` (341:697)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/employees/client.py#L151-L295" target="_blank" rel="noopener noreferrer">`square.employees.client.AsyncEmployeesClient` (151:295)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/events/client.py#L170-L350" target="_blank" rel="noopener noreferrer">`square.events.client.AsyncEventsClient` (170:350)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/gift_cards/client.py#L395-L813" target="_blank" rel="noopener noreferrer">`square.gift_cards.client.AsyncGiftCardsClient` (395:813)</a>
+- `square.inventory.client.AsyncInventoryClient` (full file reference)
+- `square.invoices.client.AsyncInvoicesClient` (full file reference)
+- `square.labor.client.AsyncLaborClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/locations/client.py#L432-L876" target="_blank" rel="noopener noreferrer">`square.locations.client.AsyncLocationsClient` (432:876)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/loyalty/client.py#L108-L199" target="_blank" rel="noopener noreferrer">`square.loyalty.client.AsyncLoyaltyClient` (108:199)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/merchants/client.py#L146-L284" target="_blank" rel="noopener noreferrer">`square.merchants.client.AsyncMerchantsClient` (146:284)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/checkout/client.py#L181-L369" target="_blank" rel="noopener noreferrer">`square.checkout.client.AsyncCheckoutClient` (181:369)</a>
+- `square.orders.client.AsyncOrdersClient` (full file reference)
+- `square.payments.client.AsyncPaymentsClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/payouts/client.py#L279-L557" target="_blank" rel="noopener noreferrer">`square.payouts.client.AsyncPayoutsClient` (279:557)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/refunds/client.py#L389-L772" target="_blank" rel="noopener noreferrer">`square.refunds.client.AsyncRefundsClient` (389:772)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/sites/client.py#L57-L107" target="_blank" rel="noopener noreferrer">`square.sites.client.AsyncSitesClient` (57:107)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/snippets/client.py#L149-L303" target="_blank" rel="noopener noreferrer">`square.snippets.client.AsyncSnippetsClient` (149:303)</a>
+- `square.subscriptions.client.AsyncSubscriptionsClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/team_members/client.py#L422-L869" target="_blank" rel="noopener noreferrer">`square.team_members.client.AsyncTeamMembersClient` (422:869)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/team/client.py#L183-L376" target="_blank" rel="noopener noreferrer">`square.team.client.AsyncTeamClient` (183:376)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/terminal/client.py#L142-L285" target="_blank" rel="noopener noreferrer">`square.terminal.client.AsyncTerminalClient` (142:285)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/vendors/client.py#L373-L778" target="_blank" rel="noopener noreferrer">`square.vendors.client.AsyncVendorsClient` (373:778)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/cash_drawers/client.py#L28-L42" target="_blank" rel="noopener noreferrer">`square.cash_drawers.client.AsyncCashDrawersClient` (28:42)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/webhooks/client.py#L32-L48" target="_blank" rel="noopener noreferrer">`square.webhooks.client.AsyncWebhooksClient` (32:48)</a>
+
+
+### Legacy SDK Core
+This component encompasses the foundational elements of the legacy SDK, including global configuration settings, OAuth2 authentication mechanisms, and the base API class that provides common functionalities like user agent management.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/configuration.py#L10-L182" target="_blank" rel="noopener noreferrer">`square_legacy.configuration.Configuration` (10:182)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/http/auth/o_auth_2.py#L6-L22" target="_blank" rel="noopener noreferrer">`square_legacy.http.auth.o_auth_2.OAuth2` (6:22)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/base_api.py#L24-L25" target="_blank" rel="noopener noreferrer">`square_legacy.api.base_api.BaseApi.user_agent` (24:25)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/api/base_api.py#L28-L33" target="_blank" rel="noopener noreferrer">`square_legacy.api.base_api.BaseApi.user_agent_parameters` (28:33)</a>
+
+
+### New SDK Core
+This component provides the core infrastructure for the new SDK, including synchronous and asynchronous client wrappers that manage HTTP requests and responses, and a utility function for determining the base URL for API calls.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/client_wrapper.py#L49-L65" target="_blank" rel="noopener noreferrer">`square.core.client_wrapper.SyncClientWrapper` (49:65)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/client_wrapper.py#L68-L84" target="_blank" rel="noopener noreferrer">`square.core.client_wrapper.AsyncClientWrapper` (68:84)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/client.py#L277-L283" target="_blank" rel="noopener noreferrer">`square.client._get_base_url` (277:283)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/SDK Configuration.md
+++ b/.codeboarding/SDK Configuration.md
@@ -1,0 +1,82 @@
+```mermaid
+graph LR
+    SDK_Configuration["SDK Configuration"]
+    Legacy_Client_Initialization["Legacy Client Initialization"]
+    Legacy_Configuration_Management["Legacy Configuration Management"]
+    Legacy_Authentication_Credentials["Legacy Authentication Credentials"]
+    New_Client_Initialization["New Client Initialization"]
+    New_Base_URL_Resolver["New Base URL Resolver"]
+    Legacy_Client_Initialization -- "configures" --> Legacy_Configuration_Management
+    Legacy_Configuration_Management -- "manages" --> Legacy_Authentication_Credentials
+    New_Client_Initialization -- "determines base URL via" --> New_Base_URL_Resolver
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph illustrates the core components involved in the Square SDK's configuration and client initialization, encompassing both legacy and modern client architectures. The main flow involves the initialization of clients, which in turn rely on dedicated configuration management and base URL resolution components to set up the necessary operational parameters and authentication credentials for API interactions.
+
+### SDK Configuration
+Manages the SDK's global settings, including authentication credentials, environment selection, and HTTP client configurations for both legacy and modern clients.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/configuration.py#L10-L182" target="_blank" rel="noopener noreferrer">`square_legacy.configuration.Configuration` (10:182)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/client.py#L277-L283" target="_blank" rel="noopener noreferrer">`square.client._get_base_url` (277:283)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/environment.py#L6-L8" target="_blank" rel="noopener noreferrer">`square.environment.SquareEnvironment` (6:8)</a>
+
+
+### Legacy Client Initialization
+This component handles the initialization of the legacy Square SDK client, primarily by configuring the SDK's operational parameters and setting up authentication.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L235-L269" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client:__init__` (235:269)</a>
+
+
+### Legacy Configuration Management
+This component is responsible for managing the SDK's configuration, including environment settings, custom URLs, access tokens, and HTTP client parameters. It also handles the creation and validation of authentication credentials and the HTTP client.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/configuration.py#L42-L80" target="_blank" rel="noopener noreferrer">`square_legacy.configuration.Configuration:__init__` (42:80)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/configuration.py#L82-L116" target="_blank" rel="noopener noreferrer">`square_legacy.configuration.Configuration:clone_with` (82:116)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/configuration.py#L168-L182" target="_blank" rel="noopener noreferrer">`square_legacy.configuration.Configuration.create_auth_credentials_object` (168:182)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/configuration.py#L162-L165" target="_blank" rel="noopener noreferrer">`square_legacy.configuration.Configuration.validate_user_agent` (162:165)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/configuration.py#L118-L126" target="_blank" rel="noopener noreferrer">`square_legacy.configuration.Configuration.create_http_client` (118:126)</a>
+
+
+### Legacy Authentication Credentials
+This component is responsible for creating and managing bearer authentication credentials used for API requests within the legacy SDK.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/http/auth/o_auth_2.py#L25-L37" target="_blank" rel="noopener noreferrer">`square_legacy.http.auth.o_auth_2.BearerAuthCredentials` (25:37)</a>
+
+
+### New Client Initialization
+This component handles the initialization of the new Square SDK client, focusing on determining the base URL for API calls.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/client.py#L117-L175" target="_blank" rel="noopener noreferrer">`square.client.Square:__init__` (117:175)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/client.py#L216-L274" target="_blank" rel="noopener noreferrer">`square.client.AsyncSquare:__init__` (216:274)</a>
+
+
+### New Base URL Resolver
+This component is responsible for resolving the base URL for the new Square SDK client, which is crucial for directing API requests to the correct endpoint.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/client.py#L277-L283" target="_blank" rel="noopener noreferrer">`square.client._get_base_url` (277:283)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,92 @@
+```mermaid
+graph LR
+    SDK_Clients["SDK Clients"]
+    Core_Communication_Utilities["Core Communication & Utilities"]
+    API_Service_Modules["API Service Modules"]
+    SDK_Configuration["SDK Configuration"]
+    SDK_Clients -- "initializes and uses" --> Core_Communication_Utilities
+    SDK_Clients -- "aggregates" --> API_Service_Modules
+    API_Service_Modules -- "sends requests via" --> Core_Communication_Utilities
+    API_Service_Modules -- "processes data with" --> Core_Communication_Utilities
+    SDK_Configuration -- "configures" --> SDK_Clients
+    SDK_Configuration -- "configures" --> Core_Communication_Utilities
+    click SDK_Clients href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/square-python-sdk/SDK Clients.md" "Details"
+    click Core_Communication_Utilities href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/square-python-sdk/Core Communication & Utilities.md" "Details"
+    click API_Service_Modules href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/square-python-sdk/API Service Modules.md" "Details"
+    click SDK_Configuration href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/square-python-sdk/SDK Configuration.md" "Details"
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The `square-python-sdk` architecture is designed around a clear separation of concerns, primarily distinguishing between legacy and modern SDK clients. The modern SDK offers both synchronous and asynchronous interfaces, all of which rely on a robust `Core Communication & Utilities` layer for HTTP requests, data handling, error management, and pagination. Specific Square API functionalities are encapsulated within `API Service Modules`, which interact with the core communication layer. Global settings and authentication are managed by the `SDK Configuration` component, which influences the behavior of both the SDK clients and the underlying communication mechanisms.
+
+### SDK Clients
+The primary entry points for interacting with the Square API, providing both synchronous and asynchronous interfaces for the modern SDK, and a single client for the legacy SDK. These clients aggregate various API-specific modules.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/client.py#L55-L269" target="_blank" rel="noopener noreferrer">`square_legacy.client.Client` (55:269)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/client.py#L79-L175" target="_blank" rel="noopener noreferrer">`square.client.Square` (79:175)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/client.py#L178-L274" target="_blank" rel="noopener noreferrer">`square.client.AsyncSquare` (178:274)</a>
+
+
+### Core Communication & Utilities
+Provides the foundational services for the SDK, including executing HTTP requests, handling data serialization/deserialization, managing API-specific errors, and facilitating pagination for API responses.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/http_client.py#L148-L321" target="_blank" rel="noopener noreferrer">`square.core.http_client.HttpClient` (148:321)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/http_client.py#L324-L497" target="_blank" rel="noopener noreferrer">`square.core.http_client.AsyncHttpClient` (324:497)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/client_wrapper.py#L9-L46" target="_blank" rel="noopener noreferrer">`square.core.client_wrapper.BaseClientWrapper` (9:46)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/client_wrapper.py#L49-L65" target="_blank" rel="noopener noreferrer">`square.core.client_wrapper.SyncClientWrapper` (49:65)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/client_wrapper.py#L68-L84" target="_blank" rel="noopener noreferrer">`square.core.client_wrapper.AsyncClientWrapper` (68:84)</a>
+- `square.core.query_encoder` (full file reference)
+- `square.core.file` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/remove_none_from_dict.py#L6-L11" target="_blank" rel="noopener noreferrer">`square.core.remove_none_from_dict` (6:11)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/unchecked_base_model.py#L36-L124" target="_blank" rel="noopener noreferrer">`square.core.unchecked_base_model.UncheckedBaseModel` (36:124)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/jsonable_encoder.py#L31-L100" target="_blank" rel="noopener noreferrer">`square.core.jsonable_encoder` (31:100)</a>
+- `square.core.serialization` (full file reference)
+- `square.core.pydantic_utilities` (full file reference)
+- `square.core.datetime_utils` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/api_error.py#L14-L123" target="_blank" rel="noopener noreferrer">`square.core.api_error.ApiError` (14:123)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/pagination.py#L37-L62" target="_blank" rel="noopener noreferrer">`square.core.pagination.SyncPager` (37:62)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/core/pagination.py#L65-L87" target="_blank" rel="noopener noreferrer">`square.core.pagination.AsyncPager` (65:87)</a>
+
+
+### API Service Modules
+A collection of specialized client modules, each dedicated to a specific Square API category (e.g., Payments, Bookings, Customers). These modules encapsulate the business logic for interacting with their respective API endpoints.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/o_auth/client.py#L17-L312" target="_blank" rel="noopener noreferrer">`square.o_auth.client.OAuthClient` (17:312)</a>
+- `square.payments.client.PaymentsClient` (full file reference)
+- `square.bookings.client.BookingsClient` (full file reference)
+- `square.catalog.client.CatalogClient` (full file reference)
+- `square.customers.client.CustomersClient` (full file reference)
+- `square.subscriptions.client.SubscriptionsClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/locations/client.py#L29-L429" target="_blank" rel="noopener noreferrer">`square.locations.client.LocationsClient` (29:429)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/terminal/client.py#L20-L139" target="_blank" rel="noopener noreferrer">`square.terminal.client.TerminalClient` (20:139)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/webhooks/client.py#L13-L29" target="_blank" rel="noopener noreferrer">`square.webhooks.client.WebhooksClient` (13:29)</a>
+- `square.inventory.client.InventoryClient` (full file reference)
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/team_members/client.py#L26-L419" target="_blank" rel="noopener noreferrer">`square.team_members.client.TeamMembersClient` (26:419)</a>
+- `square.orders.client.OrdersClient` (full file reference)
+
+
+### SDK Configuration
+Manages the SDK's global settings, including authentication credentials, environment selection, and HTTP client configurations for both legacy and modern clients.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/square/square-python-sdk/blob/master/legacy/src/square_legacy/configuration.py#L10-L182" target="_blank" rel="noopener noreferrer">`square_legacy.configuration.Configuration` (10:182)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/client.py#L277-L283" target="_blank" rel="noopener noreferrer">`square.client._get_base_url` (277:283)</a>
+- <a href="https://github.com/square/square-python-sdk/blob/master/src/square/environment.py#L6-L8" target="_blank" rel="noopener noreferrer">`square.environment.SquareEnvironment` (6:8)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
# Visualization of the square-pythno-sdk

I understand that this PR won't get merged. I usually would open a discussion on github, but since I don't need support and do not have really a feature request decided to open one. You can close it as soon as you feel like doing so.

This PR introduces high-level graph documentation for the sqyare-python-sdk. You can see how it renders here: https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/square-python-sdk/on_boarding.md

The goal of such diagram driven documentation is to help people get up-to-speed with new codebases. I would love to hear what is your current process when someone engages with your teams source code. We believe high-level understanding is crucial and just after that one can dive deeper into the interesting component. That is why we generate our diagrams in such fashion. For the generation we leverage Static Analysis and LLMs, and currently we are looking into creating a github actions so that people can generate these diagrams on demand.

Any feedback is more than welcome!

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.

# **ATTENTION**
This repository **cannot** accept Pull Requests. If you wish to proceed with opening this PR, please understand that your code **will not** be pulled into this repository. Consider opening an issue which lays out the problem instead. Thank you very much for your efforts and highlighting issues!

Please direct all technical support questions, feature requests, API-related issues, and general discussions to our Square-supported developer channels. For public support, [join us in our Square Developer Discord server](https://discord.com/invite/squaredev) or [post in our Developer Forums](https://developer.squareup.com/forums). For private support, [contact our Developer Success Engineers](https://squareup.com/help/us/en/contact?panel=BF53A9C8EF68) directly.
